### PR TITLE
Experiment using `go.work` and `replace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,20 @@ You may be able to get a more sane use case working, eg. with:
 
 - add `replace` clauses to all of your modules which depend on each other (and *don't forget to update them if you change any imports! :fire:*)
 - cross your fingers that doesn't break `go work sync`
-
+- `EDIT:` Nope - that doesn't seem to work
+  - Fine locally
+  - Breaks on external import (just in a different way):
+    ```
+    go get github.com/keilin-anz/go-work-mod-tidy-workaround/exposed@with-replace-and-url-names
+    go: downloading github.com/keilin-anz/go-work-mod-tidy-workaround/exposed v0.0.0-20221005103718-e629069e8429
+    go: downloading github.com/keilin-anz/go-work-mod-tidy-workaround v0.0.0-20221005103718-e629069e8429
+    go: downloading github.com/keilin-anz/go-work-mod-tidy-workaround/utils v0.0.0-00010101000000-000000000000
+    go: downloading github.com/keilin-anz/go-work-mod-tidy-workaround/other v0.0.0-00010101000000-000000000000
+    github.com/keilin-anz/go-work-mod-tidy-workaround/exposed imports
+    	github.com/keilin-anz/go-work-mod-tidy-workaround/other: github.com/keilin-anz/go-work-mod-tidy-workaround/other@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
+    github.com/keilin-anz/go-work-mod-tidy-workaround/exposed imports
+    	github.com/keilin-anz/go-work-mod-tidy-workaround/utils/math: github.com/keilin-anz/go-work-mod-tidy-workaround/utils@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
+    ```
 
 ### Opinion
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"go-work-mod-tidy-workaround/other"
-	"go-work-mod-tidy-workaround/utils/math"
+	"github.com/keilin-anz/go-work-mod-tidy-workaround/other"
+	"github.com/keilin-anz/go-work-mod-tidy-workaround/utils/math"
 
 	"github.com/keilin-anz/go-work-mod-tidy-workaround/exposed"
 )

--- a/exposed/exposed.go
+++ b/exposed/exposed.go
@@ -2,8 +2,9 @@ package exposed
 
 import (
 	"fmt"
-	"go-work-mod-tidy-workaround/other"
-	"go-work-mod-tidy-workaround/utils/math"
+
+	"github.com/keilin-anz/go-work-mod-tidy-workaround/other"
+	"github.com/keilin-anz/go-work-mod-tidy-workaround/utils/math"
 )
 
 // Try exposing an internal module func through this public module

--- a/exposed/go.mod
+++ b/exposed/go.mod
@@ -1,3 +1,14 @@
 module github.com/keilin-anz/go-work-mod-tidy-workaround/exposed
 
 go 1.19
+
+replace github.com/keilin-anz/go-work-mod-tidy-workaround/other => ../internal/other
+
+replace github.com/keilin-anz/go-work-mod-tidy-workaround/utils => ../internal/utils
+
+require (
+	github.com/keilin-anz/go-work-mod-tidy-workaround/other v0.0.0-00010101000000-000000000000
+	github.com/keilin-anz/go-work-mod-tidy-workaround/utils v0.0.0-00010101000000-000000000000
+)
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/exposed/go.sum
+++ b/exposed/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/other/go.mod
+++ b/internal/other/go.mod
@@ -2,4 +2,9 @@ module go-work-mod-tidy-workaround/other
 
 go 1.19
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/keilin-anz/go-work-mod-tidy-workaround/utils v0.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+replace github.com/keilin-anz/go-work-mod-tidy-workaround/utils => ../utils

--- a/internal/other/other.go
+++ b/internal/other/other.go
@@ -1,7 +1,7 @@
 package other
 
 import (
-	"go-work-mod-tidy-workaround/utils/math"
+	"github.com/keilin-anz/go-work-mod-tidy-workaround/utils/math"
 
 	// YAML library Included purely to check if `go mod tidy` works as expected
 	"gopkg.in/yaml.v3"


### PR DESCRIPTION
A variation on `main` which attempted to use a combination of `go.work` and `replace`

This is similarly undesirable and is basically the same as tests mentioned [in the original issue](https://github.com/golang/go/issues/50750)